### PR TITLE
make sure that ServerSelectionController gets destroyed on soft restart

### DIFF
--- a/UI/ServerSelectionController.cs
+++ b/UI/ServerSelectionController.cs
@@ -6,25 +6,28 @@ using BeatTogether.Providers;
 using IPA.Utilities;
 using MasterServer;
 using TMPro;
+using UnityEngine;
 
 namespace BeatTogether.UI
 {
-    internal class ServerSelectionController
+    internal class ServerSelectionController : MonoBehaviour
     {
         private static MethodInfo _unauthenticateWithMasterServerMethodInfo = typeof(UserMessageHandler)
             .GetMethod("UnauthenticateWithMasterServer", BindingFlags.Instance | BindingFlags.NonPublic);
 
-        private readonly MultiplayerModeSelectionViewController _multiplayerView;
+        private MultiplayerModeSelectionViewController _multiplayerView;
 
-        public ServerSelectionController(ListSetting listSetting, MultiplayerModeSelectionViewController multiplayerView)
+        public void Init(ListSetting listSetting, MultiplayerModeSelectionViewController multiplayerView)
         {
             _multiplayerView = multiplayerView;
-
             var changed = new BSMLAction(this, typeof(ServerSelectionController).GetMethod("OnServerChanged"));
             listSetting.onChange = changed;
             UpdateUI(multiplayerView, Plugin.ServerDetailProvider.Selection);
             GameEventDispatcher.Instance.MultiplayerViewEntered += OnMultiplayerViewEntered;
         }
+
+        public void OnDestroy()
+            => GameEventDispatcher.Instance.MultiplayerViewEntered -= OnMultiplayerViewEntered;
 
         public void OnServerChanged(object selection)
         {
@@ -101,10 +104,10 @@ namespace BeatTogether.UI
         private TextMeshProUGUI GetMaintenanceMessageText() =>
             ReflectionUtil.GetField<TextMeshProUGUI, MultiplayerModeSelectionViewController>(_multiplayerView, "_maintenanceMessageText");
 
-        private void OnMultiplayerViewEntered(object sender, MultiplayerModeSelectionViewController e)
+        private void OnMultiplayerViewEntered(object sender, MultiplayerModeSelectionViewController multiplayerView)
         {
             var selection = Plugin.ServerDetailProvider.Selection;
-            UpdateUI(_multiplayerView, selection);
+            UpdateUI(multiplayerView, selection);
         }
 
         #endregion

--- a/UI/UiFactory.cs
+++ b/UI/UiFactory.cs
@@ -10,6 +10,7 @@ namespace BeatTogether.UI
     {
         internal static ListSetting CreateServerSelectionView(MultiplayerModeSelectionViewController multiplayerView)
         {
+            Plugin.Logger.Info("Applying interface for server selection.");
             var parent = multiplayerView.gameObject.transform;
             FormattedFloatListSettingsValueController baseSetting = MonoBehaviour.Instantiate(Resources.FindObjectsOfTypeAll<FormattedFloatListSettingsValueController>().First(x => (x.name == "VRRenderingScale")), parent, false);
             baseSetting.name = "BSMLIncDecSetting";
@@ -29,7 +30,8 @@ namespace BeatTogether.UI
             (gameObject.transform.GetChild(1) as RectTransform).sizeDelta = new Vector2(60, 0);
             serverSelection.text.overflowMode = TextOverflowModes.Ellipsis;
 
-            new ServerSelectionController(serverSelection, multiplayerView);
+            var controller = multiplayerView.gameObject.AddComponent<ServerSelectionController>();
+            controller.Init(serverSelection, multiplayerView);
 
             TextMeshProUGUI text = gameObject.GetComponentInChildren<TextMeshProUGUI>();
             text.transform.position += new Vector3(1.2f, 0.0f, 0.0f);


### PR DESCRIPTION
This fixes problems with NullPointerExceptions when performing a soft restart caused by a leftover class connected to an EventHandler.