### PR TITLE
QuickplaySongPackOverrides

### DIFF
--- a/BeatTogether.csproj
+++ b/BeatTogether.csproj
@@ -134,6 +134,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Models\ServerDetails.cs" />
+    <Compile Include="Patches\MasterServerQuickPlaySetupModelPatch.cs" />
+    <Compile Include="Patches\QuickPlaySongPacksDropdownPatch.cs" />
     <Compile Include="Patches\MessageHandlerPatch.cs" />
     <Compile Include="Providers\GameClassInstanceProvider.cs" />
     <Compile Include="Providers\ServerDetailProvider.cs" />

--- a/BeatTogether.csproj
+++ b/BeatTogether.csproj
@@ -134,9 +134,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Models\ServerDetails.cs" />
+    <Compile Include="Patches\MultiplayerModeSelectionFlowCoordinatorPatch.cs" />
     <Compile Include="Patches\MasterServerQuickPlaySetupModelPatch.cs" />
     <Compile Include="Patches\QuickPlaySongPacksDropdownPatch.cs" />
     <Compile Include="Patches\MessageHandlerPatch.cs" />
+    <Compile Include="Providers\ModStatusProvider.cs" />
     <Compile Include="Providers\GameClassInstanceProvider.cs" />
     <Compile Include="Providers\ServerDetailProvider.cs" />
     <Compile Include="Providers\ServerStatusFetcher.cs" />

--- a/Patches/MasterServerQuickPlaySetupModelPatch.cs
+++ b/Patches/MasterServerQuickPlaySetupModelPatch.cs
@@ -1,0 +1,47 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using IPA.Loader;
+
+namespace BeatTogether.Patches
+{
+    [HarmonyPatch(typeof(MasterServerQuickPlaySetupModel), "Init")]
+    class MasterServerQuickPlaySetupModelInitPatch
+    {
+        public static MasterServerQuickPlaySetupModel instance { get; private set; }
+        internal static void Postfix(MasterServerQuickPlaySetupModel __instance)
+        {
+            instance = __instance;
+        }
+    }
+
+    // TODO: Should probably check if the server was switched or not, for now we just always return false
+    [HarmonyPatch(typeof(MasterServerQuickPlaySetupModel), "IsQuickPlaySetupTaskValid")]
+    class IsQuickPlaySetupTaskValidPatch
+    {
+        internal static void Postfix(MasterServerQuickPlaySetupModel __instance, ref bool __result, ref Task<MasterServerQuickPlaySetupData> ____request)
+        {
+            ____request = null;
+            __result = false;
+        }
+    }
+
+    [HarmonyPatch(typeof(MasterServerQuickPlaySetupModel), "GetQuickPlaySetupAsync")]
+    class GetQuickPlaySetupAsyncPatch
+    {
+        internal static void Postfix(MasterServerQuickPlaySetupModel __instance, ref Task<MasterServerQuickPlaySetupData> __result, ref Task<MasterServerQuickPlaySetupData> ____request)
+        {
+            var pluginMetadata = PluginManager.GetPluginFromId("MultiplayerExtensions");
+            if ((pluginMetadata == null || !PluginManager.IsEnabled(pluginMetadata)) && !Plugin.ServerDetailProvider.Selection.IsOfficial)
+            {
+                Plugin.Logger.Info("MultiplayerExtensions not installed, returning 'null'");
+                __result = new Task<MasterServerQuickPlaySetupData>(null);
+            }
+
+        }
+    }
+
+}

--- a/Patches/MasterServerQuickPlaySetupModelPatch.cs
+++ b/Patches/MasterServerQuickPlaySetupModelPatch.cs
@@ -5,16 +5,16 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using IPA.Loader;
+using BeatTogether.Providers;
 
 namespace BeatTogether.Patches
 {
     [HarmonyPatch(typeof(MasterServerQuickPlaySetupModel), "Init")]
     class MasterServerQuickPlaySetupModelInitPatch
     {
-        public static MasterServerQuickPlaySetupModel instance { get; private set; }
         internal static void Postfix(MasterServerQuickPlaySetupModel __instance)
         {
-            instance = __instance;
+            GameClassInstanceProvider.Instance.MasterServerQuickPlaySetupModel = __instance;
         }
     }
 
@@ -34,10 +34,8 @@ namespace BeatTogether.Patches
     {
         internal static void Postfix(MasterServerQuickPlaySetupModel __instance, ref Task<MasterServerQuickPlaySetupData> __result, ref Task<MasterServerQuickPlaySetupData> ____request)
         {
-            var pluginMetadata = PluginManager.GetPluginFromId("MultiplayerExtensions");
-            if ((pluginMetadata == null || !PluginManager.IsEnabled(pluginMetadata)) && !Plugin.ServerDetailProvider.Selection.IsOfficial)
+            if (ModStatusProvider.ShouldBlockSongPackOverrides)
             {
-                Plugin.Logger.Info("MultiplayerExtensions not installed, returning 'null'");
                 __result = new Task<MasterServerQuickPlaySetupData>(null);
             }
 

--- a/Patches/MultiplayerModeSelectionFlowCoordinatorPatch.cs
+++ b/Patches/MultiplayerModeSelectionFlowCoordinatorPatch.cs
@@ -1,0 +1,59 @@
+﻿using BeatTogether.Providers;
+using HarmonyLib;
+using HMUI;
+using IPA.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using QPSPDP = BeatTogether.Patches.QuickPlaySongPacksDropdownPatch;
+
+namespace BeatTogether.Patches
+{
+    [HarmonyPatch(typeof(MultiplayerModeSelectionFlowCoordinator), "HandleJoinQuickPlayViewControllerDidFinish")]
+    class MultiplayerModeSelectionFlowCoordinatorPatch
+    {
+        internal static MultiplayerModeSelectionFlowCoordinator instance;
+        internal static JoinQuickPlayViewController joinQuickPlayViewController;
+        internal static JoiningLobbyViewController joiningLobbyViewController;
+        internal static bool isWaitingForPacks = false;
+        internal static bool Prefix(MultiplayerModeSelectionFlowCoordinator __instance, bool success, JoiningLobbyViewController ____joiningLobbyViewController, JoinQuickPlayViewController ____joinQuickPlayViewController)
+        {
+            instance = __instance;
+            joinQuickPlayViewController = ____joinQuickPlayViewController;
+            joiningLobbyViewController = ____joiningLobbyViewController;
+            if (success && (QPSPDP.TaskState != QPSPDP.TaskStateEnum.Finished || QPSPDP.TaskState != QPSPDP.TaskStateEnum.Finished))
+            {
+                ____joiningLobbyViewController.Init("Loading Quickplay Pack Overrides");
+                ____joiningLobbyViewController.didCancelEvent += OnDidCancelEvent;
+                __instance.InvokeMethod<object, MultiplayerModeSelectionFlowCoordinator>("ReplaceTopViewController", new object[] {
+                                    ____joiningLobbyViewController, null, ViewController.AnimationType.In, ViewController.AnimationDirection.Vertical});
+                isWaitingForPacks = true;
+                return false;
+            } else
+            {
+                isWaitingForPacks = false;
+                return true;
+            }
+        }
+
+        internal static void OnDidCancelEvent()
+        {
+            instance.InvokeMethod<object, MultiplayerModeSelectionFlowCoordinator>("ReplaceTopViewController", new object[] {
+                                    GameClassInstanceProvider.Instance.MultiplayerModeSelectionViewController, null, ViewController.AnimationType.In, ViewController.AnimationDirection.Vertical});
+
+            joiningLobbyViewController.didCancelEvent -= OnDidCancelEvent;
+        }
+
+        public static void ShowQuickPlayLobbyScreenIfWaiting()
+        {
+            if (isWaitingForPacks && instance != null && joinQuickPlayViewController != null)
+            {
+                instance.InvokeMethod<object, MultiplayerModeSelectionFlowCoordinator>("ReplaceTopViewController", new object[] {
+                                    joinQuickPlayViewController, null, ViewController.AnimationType.In, ViewController.AnimationDirection.Vertical});
+            }
+        }
+
+    }
+}

--- a/Patches/MultiplayerModeSelectionFlowCoordinatorPatch.cs
+++ b/Patches/MultiplayerModeSelectionFlowCoordinatorPatch.cs
@@ -11,49 +11,75 @@ using QPSPDP = BeatTogether.Patches.QuickPlaySongPacksDropdownPatch;
 
 namespace BeatTogether.Patches
 {
-    [HarmonyPatch(typeof(MultiplayerModeSelectionFlowCoordinator), "HandleJoinQuickPlayViewControllerDidFinish")]
-    class MultiplayerModeSelectionFlowCoordinatorPatch
+    [HarmonyPatch(typeof(MultiplayerModeSelectionFlowCoordinator), "DidActivate")]
+    class MultiplayerModeSelectionFlowCoordinatorDidActivatePatch
     {
-        internal static MultiplayerModeSelectionFlowCoordinator instance;
-        internal static JoinQuickPlayViewController joinQuickPlayViewController;
-        internal static JoiningLobbyViewController joiningLobbyViewController;
-        internal static bool isWaitingForPacks = false;
-        internal static bool Prefix(MultiplayerModeSelectionFlowCoordinator __instance, bool success, JoiningLobbyViewController ____joiningLobbyViewController, JoinQuickPlayViewController ____joinQuickPlayViewController)
+        internal static void Prefix(MultiplayerModeSelectionFlowCoordinator __instance, JoiningLobbyViewController ____joiningLobbyViewController, JoinQuickPlayViewController ____joinQuickPlayViewController)
         {
-            instance = __instance;
-            joinQuickPlayViewController = ____joinQuickPlayViewController;
-            joiningLobbyViewController = ____joiningLobbyViewController;
-            if (success && (QPSPDP.TaskState != QPSPDP.TaskStateEnum.Finished || QPSPDP.TaskState != QPSPDP.TaskStateEnum.Finished))
-            {
-                ____joiningLobbyViewController.Init("Loading Quickplay Pack Overrides");
-                ____joiningLobbyViewController.didCancelEvent += OnDidCancelEvent;
-                __instance.InvokeMethod<object, MultiplayerModeSelectionFlowCoordinator>("ReplaceTopViewController", new object[] {
-                                    ____joiningLobbyViewController, null, ViewController.AnimationType.In, ViewController.AnimationDirection.Vertical});
-                isWaitingForPacks = true;
-                return false;
-            } else
-            {
-                isWaitingForPacks = false;
-                return true;
-            }
-        }
-
-        internal static void OnDidCancelEvent()
-        {
-            instance.InvokeMethod<object, MultiplayerModeSelectionFlowCoordinator>("ReplaceTopViewController", new object[] {
-                                    GameClassInstanceProvider.Instance.MultiplayerModeSelectionViewController, null, ViewController.AnimationType.In, ViewController.AnimationDirection.Vertical});
-
-            joiningLobbyViewController.didCancelEvent -= OnDidCancelEvent;
-        }
-
-        public static void ShowQuickPlayLobbyScreenIfWaiting()
-        {
-            if (isWaitingForPacks && instance != null && joinQuickPlayViewController != null)
-            {
-                instance.InvokeMethod<object, MultiplayerModeSelectionFlowCoordinator>("ReplaceTopViewController", new object[] {
-                                    joinQuickPlayViewController, null, ViewController.AnimationType.In, ViewController.AnimationDirection.Vertical});
-            }
+            GameClassInstanceProvider classInstanceProvider = GameClassInstanceProvider.Instance;
+            classInstanceProvider.MultiplayerModeSelectionFlowCoordinator = __instance;
+            classInstanceProvider.JoinQuickPlayViewController = ____joinQuickPlayViewController;
+            classInstanceProvider.JoiningLobbyViewController = ____joiningLobbyViewController;
         }
 
     }
+
+    //[HarmonyPatch(typeof(MultiplayerModeSelectionFlowCoordinator), "HandleMultiplayerLobbyControllerDidFinish")]
+    //class MultiplayerModeSelectionFlowCoordinatorPatch
+    //{
+    //    internal static bool isWaitingForPacks = false;
+    //    internal static bool Prefix(MultiplayerModeSelectionFlowCoordinator __instance, MultiplayerModeSelectionViewController viewController, MultiplayerModeSelectionViewController.MenuButton menuButton, JoiningLobbyViewController ____joiningLobbyViewController, JoinQuickPlayViewController ____joinQuickPlayViewController)
+    //    {
+    //        if (menuButton == MultiplayerModeSelectionViewController.MenuButton.QuickPlay && QPSPDP.TaskState == QPSPDP.TaskStateEnum.Running)
+    //        {
+    //            ____joiningLobbyViewController.Init("Loading Quickplay Pack Overrides");
+    //            ____joiningLobbyViewController.didCancelEvent += OnDidCancelEvent;
+    //            //__instance.InvokeMethod<object, MultiplayerModeSelectionFlowCoordinator>("ReplaceTopViewController", new object[] {
+    //            //                    ____joiningLobbyViewController, null, ViewController.AnimationType.In, ViewController.AnimationDirection.Vertical});
+    //            __instance.InvokeMethod<object, MultiplayerModeSelectionFlowCoordinator>("PresentViewController", new object[] {
+    //                                ____joiningLobbyViewController, null, ViewController.AnimationDirection.Vertical, false});
+    //            isWaitingForPacks = true;
+    //            ShowQuickPlayLobbyScreenIfWaiting();
+    //            return false;
+    //        } else
+    //        {
+    //            isWaitingForPacks = false;
+    //            return true;
+    //        }
+    //    }
+
+    //    internal static void OnDidCancelEvent()
+    //    {
+    //        GameClassInstanceProvider classInstanceProvider = GameClassInstanceProvider.Instance;
+    //        //classInstanceProvider.JoinQuickPlayViewController.gameObject.SetActive(true);
+    //        //classInstanceProvider.MultiplayerModeSelectionFlowCoordinator.InvokeMethod<object, MultiplayerModeSelectionFlowCoordinator>("DismissViewController", new object[] {
+    //        //                        classInstanceProvider.JoiningLobbyViewController, ViewController.AnimationDirection.Vertical, null, false});
+    //        classInstanceProvider.MultiplayerModeSelectionFlowCoordinator.InvokeMethod<object, MultiplayerModeSelectionFlowCoordinator>("PresentViewController", new object[] {
+    //                                classInstanceProvider.MultiplayerModeSelectionViewController, null, ViewController.AnimationDirection.Vertical, false});
+    //        //classInstanceProvider.MultiplayerModeSelectionFlowCoordinator.InvokeMethod<object, MultiplayerModeSelectionFlowCoordinator>("ReplaceTopViewController", new object[] {
+    //        //                        classInstanceProvider.MultiplayerModeSelectionViewController, null, ViewController.AnimationType.In, ViewController.AnimationDirection.Vertical});
+
+
+    //        classInstanceProvider.JoiningLobbyViewController.didCancelEvent -= OnDidCancelEvent;
+    //    }
+
+    //    public static void ShowQuickPlayLobbyScreenIfWaiting()
+    //    {
+    //        GameClassInstanceProvider classInstanceProvider = GameClassInstanceProvider.Instance;
+    //        MultiplayerModeSelectionFlowCoordinator instance = classInstanceProvider.MultiplayerModeSelectionFlowCoordinator;
+    //        if (isWaitingForPacks && instance != null && classInstanceProvider.JoinQuickPlayViewController != null && QPSPDP.TaskState != QPSPDP.TaskStateEnum.Running)
+    //        {
+    //            classInstanceProvider.JoinQuickPlayViewController.Setup(
+    //                ReflectionUtil.GetField<MasterServerQuickPlaySetupData, MultiplayerModeSelectionFlowCoordinator>(instance, "_masterServerQuickPlaySetupData"), 
+    //                ReflectionUtil.GetField<PlayerDataModel, MultiplayerModeSelectionFlowCoordinator>(instance, "_playerDataModel").playerData.multiplayerModeSettings);
+    //            instance.InvokeMethod<object, MultiplayerModeSelectionFlowCoordinator>("PresentViewController", new object[] {
+    //                                classInstanceProvider.JoinQuickPlayViewController,  null, ViewController.AnimationDirection.Vertical, false});
+    //        }
+    //        else
+    //        {
+    //            Plugin.Logger.Debug($"isWaitingForPacks: {(isWaitingForPacks ? "true" : "false")}, QPSPDP.TaskState: {(QPSPDP.TaskState)}");
+    //        }
+    //    }
+
+    //}
 }

--- a/Patches/QuickPlaySongPacksDropdownPatch.cs
+++ b/Patches/QuickPlaySongPacksDropdownPatch.cs
@@ -1,0 +1,78 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using IPA.Utilities;
+using IPA.Loader;
+// TODO: Add some sort of loadingScreen while it checks SongPackOverrides
+namespace BeatTogether.Patches
+{
+    [HarmonyPatch(typeof(QuickPlaySongPacksDropdown), "Start")]
+    internal class QuickPlaySongPacksDropdownPatch
+    {
+        internal static QuickPlaySongPacksDropdown _instance;
+        internal static bool didTaskFail;
+        internal static void Prefix(QuickPlaySongPacksDropdown __instance)
+        {
+            _instance = __instance;
+        }
+
+        public static void UpdateSongPacks()
+        {
+            _instance.SetField<QuickPlaySongPacksDropdown, MasterServerQuickPlaySetupData.QuickPlaySongPacksOverride>("_quickPlaySongPacksOverride", null);
+            var pluginMetadata = PluginManager.GetPluginFromId("MultiplayerExtensions");
+            if ((pluginMetadata == null || !PluginManager.IsEnabled(pluginMetadata)) && !Plugin.ServerDetailProvider.Selection.IsOfficial)
+            {
+                Plugin.Logger.Info("MultiplayerExtensions not installed, not overriding packs");
+                return;
+            }
+
+            System.Threading.Tasks.Task.Run(async () =>
+            {
+                try
+                {
+                    Plugin.Logger.Info("Get QuickPlaySongPacksOverride");
+                    var quickPlaySetupData = await MasterServerQuickPlaySetupModelInitPatch.instance.GetQuickPlaySetupAsync(System.Threading.CancellationToken.None);
+                    didTaskFail = false;
+                    return quickPlaySetupData.quickPlayAvailablePacksOverride;
+                }
+                catch (Exception)
+                {
+                    Plugin.Logger.Info("Could not get QuickPlaySongPacksOverride");
+                    didTaskFail = true;
+                    return null;
+                }
+            }).ContinueWith(r =>
+            {
+                Plugin.Logger.Debug("ContinueWith running for quickplaySongPackOverrides");
+                _instance.SetField("_quickPlaySongPacksOverride", r.Result);
+                _instance.SetField("_initialized", false);
+                //_instance.LazyInit();
+            }
+            );
+        }
+    }
+
+    [HarmonyPatch(typeof(QuickPlaySongPacksDropdown), "LazyInit")]
+    class QuickPlaySongPacksDropdownLazyInitPatch
+    {
+        internal static void Prefix(QuickPlaySongPacksDropdown __instance, ref MasterServerQuickPlaySetupData.QuickPlaySongPacksOverride ____quickPlaySongPacksOverride, ref bool ____initialized)
+        {
+            var pluginMetadata = PluginManager.GetPluginFromId("MultiplayerExtensions");
+            if ((pluginMetadata == null || !PluginManager.IsEnabled(pluginMetadata)) && !Plugin.ServerDetailProvider.Selection.IsOfficial)
+            {
+                Plugin.Logger.Info("MultiplayerExtensions not installed, not overriding packs");
+                ____quickPlaySongPacksOverride = null;
+                ____initialized = false;
+            }
+            else if (QuickPlaySongPacksDropdownPatch.didTaskFail)
+            {
+                ____quickPlaySongPacksOverride = null;
+                ____initialized = false;
+            }
+        }
+    }
+
+}

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("BeatTogether")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Providers/GameClassInstanceProvider.cs
+++ b/Providers/GameClassInstanceProvider.cs
@@ -15,5 +15,10 @@ namespace BeatTogether.Providers
         public MultiplayerModeSelectionViewController MultiplayerModeSelectionViewController { get; set; }
         public MasterServerQuickPlaySetupModel MasterServerQuickPlaySetupModel { get; set; }
         public QuickPlaySongPacksDropdown QuickPlaySongPacksDropdown { get; set; }
+
+        public MultiplayerModeSelectionFlowCoordinator MultiplayerModeSelectionFlowCoordinator { get; set; }
+        public JoinQuickPlayViewController JoinQuickPlayViewController { get; set; }
+        public JoiningLobbyViewController JoiningLobbyViewController { get; set; }
+
     }
 }

--- a/Providers/GameClassInstanceProvider.cs
+++ b/Providers/GameClassInstanceProvider.cs
@@ -13,5 +13,7 @@ namespace BeatTogether.Providers
 
         public UserMessageHandler UserMessageHandler { get; set; }
         public MultiplayerModeSelectionViewController MultiplayerModeSelectionViewController { get; set; }
+        public MasterServerQuickPlaySetupModel MasterServerQuickPlaySetupModel { get; set; }
+        public QuickPlaySongPacksDropdown QuickPlaySongPacksDropdown { get; set; }
     }
 }

--- a/Providers/ModStatusProvider.cs
+++ b/Providers/ModStatusProvider.cs
@@ -1,0 +1,22 @@
+﻿using IPA.Loader;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeatTogether.Providers
+{
+    internal class ModStatusProvider
+    {
+        public static bool ShouldBlockSongPackOverrides 
+        { 
+            get {
+                var pluginMetadata = PluginManager.GetPluginFromId("MultiplayerExtensions");
+                bool valid = ((pluginMetadata == null || !PluginManager.IsEnabled(pluginMetadata)) && !Plugin.ServerDetailProvider.Selection.IsOfficial);
+                if (valid) Plugin.Logger.Info("On Official Servers or not modded with MpEx!");
+                return valid;
+                }
+        }
+    }
+}

--- a/UI/ServerSelectionController.cs
+++ b/UI/ServerSelectionController.cs
@@ -35,6 +35,8 @@ namespace BeatTogether.UI
             Plugin.Configuration.SelectedServer = details.ServerName;
             Plugin.ServerDetailProvider.Selection = details;
 
+            Patches.QuickPlaySongPacksDropdownPatch.UpdateSongPacks();
+
             // Keep this code, as it informs MPEX of the change
             // (by invoking the getters):
             var networkConfig = GetNetworkConfig();
@@ -44,8 +46,6 @@ namespace BeatTogether.UI
                 "Master server selection changed " +
                 $"(EndPoint={endPoint}, StatusUrl={statusUrl})"
             );
-
-            Patches.QuickPlaySongPacksDropdownPatch.UpdateSongPacks();
 
             DisconnectServer();
             UpdateUI(_multiplayerView, details);

--- a/UI/ServerSelectionController.cs
+++ b/UI/ServerSelectionController.cs
@@ -45,6 +45,8 @@ namespace BeatTogether.UI
                 $"(EndPoint={endPoint}, StatusUrl={statusUrl})"
             );
 
+            Patches.QuickPlaySongPacksDropdownPatch.UpdateSongPacks();
+
             DisconnectServer();
             UpdateUI(_multiplayerView, details);
         }

--- a/UI/UIFactory.cs
+++ b/UI/UIFactory.cs
@@ -41,6 +41,8 @@ namespace BeatTogether.UI
             gameObject.GetComponent<LayoutElement>().preferredWidth = 90;
             gameObject.SetActive(true);
 
+            // Initial Update for the SongPacks
+            Patches.QuickPlaySongPacksDropdownPatch.UpdateSongPacks();
             return serverSelection;
         }
     }


### PR DESCRIPTION
This will add the code necessary to handle QuickplaySongPackOverrides into BT

**TODO:**
- [x] Add code for switching reloading SongPackOverrides when switching Server
- [x] Add code that disables SongPackOverrides for non-official servers when MpEx is missing
- [x]  Add loading screen when opening Quickplay selection before loading of the overrides has finished
- [x] Possibly optimize this ended up to become quite a lot of code