### PR TITLE
Fix official server selection / keep selected server in sync

### DIFF
--- a/BeatTogether/Registries/ServerDetailsRegistry.cs
+++ b/BeatTogether/Registries/ServerDetailsRegistry.cs
@@ -13,11 +13,12 @@ namespace BeatTogether.Registries
             ?? Servers.FirstOrDefault(details => details.ServerName == Config.BeatTogetherServerName);
 
         public IReadOnlyList<ServerDetails> Servers
-            => _config.Servers.Concat(_servers).Append(_officialServer).ToList();
+            => _config.Servers.Concat(_servers).Append(OfficialServer).ToList();
 
         private readonly Config _config;
         private readonly List<ServerDetails> _servers = new();
-        private readonly ServerDetails _officialServer = new()
+        
+        public readonly ServerDetails OfficialServer = new()
         {
             ServerName = Config.OfficialServerName
         };


### PR DESCRIPTION
There's an issue where before/after using Official Servers via the Server Browser (or any other mod that would do this), they would not be selected properly in the BeatTogether selector.

This creates a confusing situation where it looks like you're creating a BeatTogether lobby when you're really creating an official one.

Changes in this PR:
 - BeatTogether mod will now only override network configuration on first start, for secondary activations it'll just sync from MultiplayerCore's network configuration.
 - Official Servers will now be selected properly when they're supposed to.
 - Cleaned up the server selection code overall so it's a bit easier to understand what's happening.

Scenarios this handles / that I've tested:
 - BeatTogether applies its config and selects the corresponding server on startup
 - BeatTogether server switching works as expected 
 - When connecting to any server via Server Browser - official, BeatTogether, other 3rd party, including servers not known in config, BeatTogether syncs the value correctly