### PR TITLE
1.29 support (Graph API) 

### DIFF
--- a/BeatTogether/Config.cs
+++ b/BeatTogether/Config.cs
@@ -16,22 +16,30 @@ namespace BeatTogether
         public const string BeatTogetherHostName = "master.beattogether.systems";
         public const string BeatTogetherStatusUri = "http://master.beattogether.systems/status";
         public const int BeatTogetherMaxPartySize = 100;
+        public const int BeatTogetherApiPort = 80;
+        public const bool BeatTogetherApiSecure = false;
 
         public virtual string SelectedServer { get; set; } = BeatTogetherServerName;
 
         [NonNullable, UseConverter(typeof(CollectionConverter<ServerDetails, List<ServerDetails?>>))]
-        public virtual List<ServerDetails> Servers { get; set; } = new List<ServerDetails>();
+        public virtual List<ServerDetails> Servers { get; set; } = new();
 
         public virtual void OnReload()
         {
-            if (Servers.All(server => server.ServerName != BeatTogetherServerName))
-                Servers.Insert(0, new ServerDetails
-                {
-                    ServerName = BeatTogetherServerName,
-                    HostName = BeatTogetherHostName,
-                    StatusUri = BeatTogetherStatusUri,
-                    MaxPartySize = BeatTogetherMaxPartySize
-                });
+            var btServer = Servers.FirstOrDefault(server => server.ServerName == BeatTogetherServerName);
+
+            if (btServer != null)
+                return;
+            
+            Servers.Insert(0, new ServerDetails
+            {
+                ServerName = BeatTogetherServerName,
+                HostName = BeatTogetherHostName,
+                StatusUri = BeatTogetherStatusUri,
+                MaxPartySize = BeatTogetherMaxPartySize,
+                ApiPort = BeatTogetherApiPort,
+                ApiSecure = BeatTogetherApiSecure
+            });
         }
 
         public virtual void CopyFrom(Config other)

--- a/BeatTogether/Config.cs
+++ b/BeatTogether/Config.cs
@@ -12,12 +12,12 @@ namespace BeatTogether
         public const string OfficialServerName = "Official Servers";
 
         // BeatTogether master server config
+        public const int DefaultApiPort = 8989;
         public const string BeatTogetherServerName = "BeatTogether";
         public const string BeatTogetherHostName = "master.beattogether.systems";
+        public const string BeatTogetherApiUri = "http://master.beattogether.systems:8989";
         public const string BeatTogetherStatusUri = "http://master.beattogether.systems/status";
         public const int BeatTogetherMaxPartySize = 100;
-        public const int BeatTogetherApiPort = 80;
-        public const bool BeatTogetherApiSecure = false;
 
         public virtual string SelectedServer { get; set; } = BeatTogetherServerName;
 
@@ -26,20 +26,29 @@ namespace BeatTogether
 
         public virtual void OnReload()
         {
-            var btServer = Servers.FirstOrDefault(server => server.ServerName == BeatTogetherServerName);
-
-            if (btServer != null)
-                return;
+            var haveBtServer = false;
             
-            Servers.Insert(0, new ServerDetails
+            foreach (var server in Servers)
             {
-                ServerName = BeatTogetherServerName,
-                HostName = BeatTogetherHostName,
-                StatusUri = BeatTogetherStatusUri,
-                MaxPartySize = BeatTogetherMaxPartySize,
-                ApiPort = BeatTogetherApiPort,
-                ApiSecure = BeatTogetherApiSecure
-            });
+                if (server.ServerName == BeatTogetherServerName)
+                    haveBtServer = true;
+                
+                // Try to auto migrate API URL if missing from older configs
+                if (string.IsNullOrEmpty(server.ApiUrl))
+                    server.ApiUrl = $"http://{server.HostName}:{DefaultApiPort}";
+            }
+
+            if (!haveBtServer)
+            {
+                Servers.Insert(0, new ServerDetails
+                {
+                    ServerName = BeatTogetherServerName,
+                    HostName = BeatTogetherHostName,
+                    ApiUrl = BeatTogetherApiUri,
+                    StatusUri = BeatTogetherStatusUri,
+                    MaxPartySize = BeatTogetherMaxPartySize
+                });
+            }
         }
 
         public virtual void CopyFrom(Config other)

--- a/BeatTogether/Models/ServerDetails.cs
+++ b/BeatTogether/Models/ServerDetails.cs
@@ -1,15 +1,78 @@
-﻿namespace BeatTogether.Models
+﻿using System;
+using System.Security.Policy;
+
+namespace BeatTogether.Models
 {
     public class ServerDetails
     {
+        /// <summary>
+        /// Display name for UI
+        /// </summary>
         public string ServerName { get; set; } = string.Empty;
+        /// <summary>
+        /// Hostname for master server and API url
+        /// </summary>
         public string HostName { get; set; } = string.Empty;
+        /// <summary>
+        /// Port number for master/auth server
+        /// </summary>
         public int Port { get; set; } = 2328;
+        /// <summary>
+        /// Optional status check URL for the server
+        /// </summary>
         public string StatusUri { get; set; } = string.Empty;
+        /// <summary>
+        /// Max amount of players per instance 
+        /// </summary>
         public int MaxPartySize { get; set; } = 5;
+        /// <summary>
+        /// HTTP port number for Graph API server
+        /// </summary>
+        public int ApiPort { get; set; } = 80;
+        /// <summary>
+        /// Whether Graph API requests should use HTTPS protocol
+        /// </summary>
+        public bool ApiSecure { get; set; } = false;
 
         public DnsEndPoint? EndPoint => string.IsNullOrEmpty(ServerName) ? null : new(HostName, Port);
+
+        public string ApiUrl
+        {
+            get
+            {
+                var protocol = ApiSecure ? "https" : "http";
+                return $"{protocol}://{HostName}:{ApiPort}";
+            }
+        }
+        
         public bool IsOfficial => ServerName == Config.OfficialServerName;
+
+        /// <summary>
+        /// Gets whether this server matches against a given override URL.
+        /// Only checks whether the hostname and port match.
+        /// </summary>
+        public bool MatchesApiUrl(string? apiUrl)
+        {
+            if (string.IsNullOrEmpty(apiUrl))
+                return false;
+            
+            Console.WriteLine(apiUrl);
+
+            try
+            {
+                var urlParsed = new Uri(apiUrl);
+                
+                Console.WriteLine($"parsed.Host = {urlParsed.Host}");
+                Console.WriteLine($"parsed.Port = {urlParsed.Port}");
+                
+                return urlParsed.Host == HostName && urlParsed.Port == ApiPort;
+            }
+            catch (UriFormatException ex)
+            {
+                Console.WriteLine(ex.Message);
+                return false;
+            }
+        }
 
         public override string ToString() => ServerName;
     }

--- a/BeatTogether/Models/ServerDetails.cs
+++ b/BeatTogether/Models/ServerDetails.cs
@@ -10,13 +10,13 @@ namespace BeatTogether.Models
         /// </summary>
         public string ServerName { get; set; } = string.Empty;
         /// <summary>
-        /// Hostname for master server and API url
+        /// Legacy hostname for master server (no longer used, except for automatic config migrations)
         /// </summary>
         public string HostName { get; set; } = string.Empty;
         /// <summary>
-        /// Port number for master/auth server
+        /// The multiplayer API url / graph url 
         /// </summary>
-        public int Port { get; set; } = 2328;
+        public string ApiUrl { get; set; } = string.Empty;
         /// <summary>
         /// Optional status check URL for the server
         /// </summary>
@@ -25,26 +25,7 @@ namespace BeatTogether.Models
         /// Max amount of players per instance 
         /// </summary>
         public int MaxPartySize { get; set; } = 5;
-        /// <summary>
-        /// HTTP port number for Graph API server
-        /// </summary>
-        public int ApiPort { get; set; } = 80;
-        /// <summary>
-        /// Whether Graph API requests should use HTTPS protocol
-        /// </summary>
-        public bool ApiSecure { get; set; } = false;
 
-        public DnsEndPoint? EndPoint => string.IsNullOrEmpty(ServerName) ? null : new(HostName, Port);
-
-        public string ApiUrl
-        {
-            get
-            {
-                var protocol = ApiSecure ? "https" : "http";
-                return $"{protocol}://{HostName}:{ApiPort}";
-            }
-        }
-        
         public bool IsOfficial => ServerName == Config.OfficialServerName;
 
         /// <summary>
@@ -53,23 +34,24 @@ namespace BeatTogether.Models
         /// </summary>
         public bool MatchesApiUrl(string? apiUrl)
         {
+            if (apiUrl == ApiUrl)
+                // Exact match
+                return true;
+            
             if (string.IsNullOrEmpty(apiUrl))
                 return false;
             
-            Console.WriteLine(apiUrl);
-
+            // Loose match
             try
             {
-                var urlParsed = new Uri(apiUrl);
+                var urlOurs = new Uri(ApiUrl);
+                var urlTheirs = new Uri(apiUrl);
                 
-                Console.WriteLine($"parsed.Host = {urlParsed.Host}");
-                Console.WriteLine($"parsed.Port = {urlParsed.Port}");
-                
-                return urlParsed.Host == HostName && urlParsed.Port == ApiPort;
+                return urlOurs.Host == urlTheirs.Host &&
+                       urlOurs.Port == urlTheirs.Port;
             }
-            catch (UriFormatException ex)
+            catch (UriFormatException)
             {
-                Console.WriteLine(ex.Message);
                 return false;
             }
         }

--- a/BeatTogether/Models/TemporaryServerDetails.cs
+++ b/BeatTogether/Models/TemporaryServerDetails.cs
@@ -4,23 +4,23 @@ namespace BeatTogether.Models
 {
     public class TemporaryServerDetails : ServerDetails
     {
-        public TemporaryServerDetails(string apiUrl, int masterServerPort)
+        public TemporaryServerDetails(string graphApiUrl, string? statusUrl)
         {
             try
             {
-                var urlParsed = new Uri(apiUrl);
+                var urlParsed = new Uri(graphApiUrl);
 
                 ServerName = urlParsed.Host;
                 HostName = urlParsed.Host;
             }
             catch (UriFormatException)
             {
-                ServerName = apiUrl;
-                HostName = apiUrl;
+                ServerName = graphApiUrl;
+                HostName = graphApiUrl;
             }
             
-            ApiUrl = apiUrl;
-            StatusUri = string.Empty;
+            ApiUrl = graphApiUrl;
+            StatusUri = statusUrl ?? graphApiUrl;
             MaxPartySize = IsOfficial ? 5 : 128;
         }
     }

--- a/BeatTogether/Models/TemporaryServerDetails.cs
+++ b/BeatTogether/Models/TemporaryServerDetails.cs
@@ -1,14 +1,20 @@
-﻿namespace BeatTogether.Models
+﻿using System;
+
+namespace BeatTogether.Models
 {
     public class TemporaryServerDetails : ServerDetails
     {
-        public TemporaryServerDetails(DnsEndPoint masterServerEndPoint)
+        public TemporaryServerDetails(string apiUrl, int masterServerPort)
         {
-            ServerName = masterServerEndPoint.hostName;
-            HostName = masterServerEndPoint.hostName;
-            Port = masterServerEndPoint.port;
+            var urlParsed = new Uri(apiUrl);
+
+            ServerName = urlParsed.Host;
+            HostName = urlParsed.Host;
+            Port = masterServerPort;
             StatusUri = string.Empty;
             MaxPartySize = IsOfficial ? 5 : 128;
+            ApiPort = urlParsed.Port;
+            ApiSecure = urlParsed.Scheme.Equals("https", StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/BeatTogether/Models/TemporaryServerDetails.cs
+++ b/BeatTogether/Models/TemporaryServerDetails.cs
@@ -6,15 +6,22 @@ namespace BeatTogether.Models
     {
         public TemporaryServerDetails(string apiUrl, int masterServerPort)
         {
-            var urlParsed = new Uri(apiUrl);
+            try
+            {
+                var urlParsed = new Uri(apiUrl);
 
-            ServerName = urlParsed.Host;
-            HostName = urlParsed.Host;
-            Port = masterServerPort;
+                ServerName = urlParsed.Host;
+                HostName = urlParsed.Host;
+            }
+            catch (UriFormatException)
+            {
+                ServerName = apiUrl;
+                HostName = apiUrl;
+            }
+            
+            ApiUrl = apiUrl;
             StatusUri = string.Empty;
             MaxPartySize = IsOfficial ? 5 : 128;
-            ApiPort = urlParsed.Port;
-            ApiSecure = urlParsed.Scheme.Equals("https", StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/BeatTogether/UI/ServerSelectionController.cs
+++ b/BeatTogether/UI/ServerSelectionController.cs
@@ -104,7 +104,7 @@ namespace BeatTogether.UI
             if (server.IsOfficial)
                 _networkConfig.UseOfficialServer();
             else
-                _networkConfig.UseMasterServer(server.EndPoint!, server.StatusUri, server.MaxPartySize);
+                _networkConfig.UseCustomApiServer(server.ApiUrl, server.StatusUri, server.MaxPartySize);
 
             SyncTemporarySelectedServer();
 
@@ -120,11 +120,11 @@ namespace BeatTogether.UI
         {
             ServerDetails selectedServer;
             
-            if (_networkConfig.MasterServerEndPoint is not null)
+            if (_networkConfig.IsOverridingApi)
             {
                 // Master server is being patched by MpCore, sync our selection
                 var knownServer = _serverRegistry.Servers.FirstOrDefault(serverDetails =>
-                    serverDetails.EndPoint?.Equals(_networkConfig.MasterServerEndPoint) ?? false);
+                    serverDetails.MatchesApiUrl(_networkConfig.GraphUrl));
 
                 if (knownServer != null)
                 {
@@ -134,8 +134,9 @@ namespace BeatTogether.UI
                 else
                 {
                     // Selected server is not in our config, set temporary value
-                    _logger.Debug($"Setting temporary server details (MasterServerEndPoint={_networkConfig.MasterServerEndPoint})");
-                    selectedServer = new TemporaryServerDetails(_networkConfig.MasterServerEndPoint);
+                    // TODO
+                    _logger.Error($"Server not in config // TODO // not supported right now");
+                    return;
                 }
             }
             else
@@ -188,7 +189,7 @@ namespace BeatTogether.UI
                 if (_serverRegistry.SelectedServer.IsOfficial)
                     _networkConfig.UseOfficialServer();
                 else
-                    _networkConfig.UseMasterServer(_serverRegistry.SelectedServer.EndPoint!,
+                    _networkConfig.UseCustomApiServer(_serverRegistry.SelectedServer.ApiUrl,
                         _serverRegistry.SelectedServer.StatusUri, _serverRegistry.SelectedServer.MaxPartySize);
                 
                 _isFirstActivation = false;

--- a/BeatTogether/UI/ServerSelectionController.cs
+++ b/BeatTogether/UI/ServerSelectionController.cs
@@ -99,7 +99,7 @@ namespace BeatTogether.UI
             if (server is TemporaryServerDetails)
                 return;
             
-            _logger.Debug($"Server changed to '{server.ServerName}': '{server.HostName}:{server.Port}'");
+            _logger.Debug($"Server changed to '{server.ServerName}': '{server.ApiUrl}'");
             _serverRegistry.SetSelectedServer(server);
             if (server.IsOfficial)
                 _networkConfig.UseOfficialServer();

--- a/BeatTogether/UI/ServerSelectionController.cs
+++ b/BeatTogether/UI/ServerSelectionController.cs
@@ -134,9 +134,8 @@ namespace BeatTogether.UI
                 else
                 {
                     // Selected server is not in our config, set temporary value
-                    // TODO
-                    _logger.Error($"Server not in config // TODO // not supported right now");
-                    return;
+                    _logger.Debug($"Setting temporary server details (GraphUrl={_networkConfig.GraphUrl})");
+                    selectedServer = new TemporaryServerDetails(_networkConfig.GraphUrl!, _networkConfig.MasterServerStatusUrl);
                 }
             }
             else

--- a/BeatTogether/manifest.json
+++ b/BeatTogether/manifest.json
@@ -3,9 +3,9 @@
   "id": "BeatTogether",
   "name": "BeatTogether",
   "author": "Goobwabber",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A multiplayer private server for the modding community. Supports crossplay between PC and Quest.",
-  "gameVersion": "1.21.0",
+  "gameVersion": "1.29.0",
   "dependsOn": {
     "BSIPA": "^4.2.0",
     "BeatSaberMarkupLanguage": "^1.5.0",

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ Want to support development and server costs? [Click Here](https://www.patreon.c
 * 10 Player lobbies
 
 ## Requirements
-These can be downloaded from [BeatMods](https://beatmods.com/#/mods) or using Mod Assistant.
+This version supports Beat Saber 1.29+ with mods:
+
 * BSIPA v4.1.4+
 * BeatSaberMarkupLanguage v1.6.6+
-* [MultiplayerCore v1.0.0+](https://github.com/Goobwabber/MultiplayerCore#installation)
+* [MultiplayerCore v1.3.0+](https://github.com/Goobwabber/MultiplayerCore#installation)
+
+These can be downloaded from [BeatMods](https://beatmods.com/#/mods) or using Mod Assistant.
 
 ## Installation
 


### PR DESCRIPTION
This PR adds support for Beat Saber 1.29 where classic master servers are dead:

- Targets the proposed new MultiplayerCore version with Graph URL patching rather than master server patching
- Server configs are now based on an `ApiUrl` e.g. `http://master.beattogether.systems:8989`
- Assumes an arbitrary default API port of `8989` and automatically migrates previous server configs
- Bumps BeatTogether version to 2.1.0 and target Beat Saber 1.29.0

### Cross-dependent related PRs
- https://github.com/Goobwabber/MultiplayerCore/pull/41 
- https://github.com/BeatTogether/BeatTogether.MasterServer/pull/63
- https://github.com/BeatTogether/BeatTogether.DedicatedServer/pull/128