### PR TITLE
1.31 Support 

### DIFF
--- a/BeatTogether/Config.cs
+++ b/BeatTogether/Config.cs
@@ -46,7 +46,8 @@ namespace BeatTogether
                     HostName = BeatTogetherHostName,
                     ApiUrl = BeatTogetherApiUri,
                     StatusUri = BeatTogetherStatusUri,
-                    MaxPartySize = BeatTogetherMaxPartySize
+                    MaxPartySize = BeatTogetherMaxPartySize,
+                    DisableSsl = true
                 });
             }
         }

--- a/BeatTogether/Models/ServerDetails.cs
+++ b/BeatTogether/Models/ServerDetails.cs
@@ -25,6 +25,10 @@ namespace BeatTogether.Models
         /// Max amount of players per instance 
         /// </summary>
         public int MaxPartySize { get; set; } = 5;
+        /// <summary>
+        /// If set: disable SSL and certificate validation for all Ignorance/ENet client connections.
+        /// </summary>
+        public bool DisableSsl { get; set; } = true;
 
         public bool IsOfficial => ServerName == Config.OfficialServerName;
 

--- a/BeatTogether/Models/TemporaryServerDetails.cs
+++ b/BeatTogether/Models/TemporaryServerDetails.cs
@@ -22,6 +22,7 @@ namespace BeatTogether.Models
             ApiUrl = graphApiUrl;
             StatusUri = statusUrl ?? graphApiUrl;
             MaxPartySize = IsOfficial ? 5 : 128;
+            DisableSsl = true;
         }
     }
 }

--- a/BeatTogether/UI/ServerSelectionController.cs
+++ b/BeatTogether/UI/ServerSelectionController.cs
@@ -100,12 +100,9 @@ namespace BeatTogether.UI
                 return;
             
             _logger.Debug($"Server changed to '{server.ServerName}': '{server.ApiUrl}'");
+            
             _serverRegistry.SetSelectedServer(server);
-            if (server.IsOfficial)
-                _networkConfig.UseOfficialServer();
-            else
-                _networkConfig.UseCustomApiServer(server.ApiUrl, server.StatusUri, server.MaxPartySize);
-
+            ApplyNetworkConfig(server);
             SyncTemporarySelectedServer();
 
             SetInteraction(false);
@@ -114,6 +111,15 @@ namespace BeatTogether.UI
             _didActivate(_modeSelectionFlow, false, true, false);
             _replaceTopScreenViewController(_modeSelectionFlow, _joiningLobbyView, () => { },
                 ViewController.AnimationType.None, ViewController.AnimationDirection.Vertical);
+        }
+
+        private void ApplyNetworkConfig(ServerDetails server)
+        {
+            if (server.IsOfficial)
+                _networkConfig.UseOfficialServer();
+            else
+                _networkConfig.UseCustomApiServer(server.ApiUrl, server.StatusUri, server.MaxPartySize,
+                    null, server.DisableSsl);
         }
         
         private void SyncSelectedServer()
@@ -185,12 +191,7 @@ namespace BeatTogether.UI
             if (_isFirstActivation)
             {
                 // First activation: apply the currently selected server (from our config)
-                if (_serverRegistry.SelectedServer.IsOfficial)
-                    _networkConfig.UseOfficialServer();
-                else
-                    _networkConfig.UseCustomApiServer(_serverRegistry.SelectedServer.ApiUrl,
-                        _serverRegistry.SelectedServer.StatusUri, _serverRegistry.SelectedServer.MaxPartySize);
-                
+                ApplyNetworkConfig(_serverRegistry.SelectedServer);
                 _isFirstActivation = false;
             }
             else

--- a/BeatTogether/manifest.json
+++ b/BeatTogether/manifest.json
@@ -3,14 +3,13 @@
   "id": "BeatTogether",
   "name": "BeatTogether",
   "author": "Goobwabber",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A multiplayer private server for the modding community. Supports crossplay between PC and Quest.",
-  "gameVersion": "1.29.0",
+  "gameVersion": "1.31.0",
   "dependsOn": {
-    "BSIPA": "^4.2.0",
-    "BeatSaberMarkupLanguage": "^1.5.0",
-    "SiraUtil": "^3.1.0",
-    "MultiplayerCore": "^1.3.0"
-  },
-  "features": []
+    "BSIPA": "^4.3.0",
+    "BeatSaberMarkupLanguage": "^1.7.3",
+    "SiraUtil": "^3.1.3",
+    "MultiplayerCore": "^1.5.0"
+  }
 }


### PR DESCRIPTION
The BeatTogether plugin doesn't strictly require updates for 1.31, but this PR brings it in line with proposed changes to MultiplayerCore, and will allow server operators to define whether they support SSL/DTLS or not.

Related PR: https://github.com/Goobwabber/MultiplayerCore/pull/45

- Targets proposed MultiplayerCore 1.5
- Adds `DisableSsl` setting for servers - defaults to `true` and migrates existing configs as such
- Automatically adjust `DisableSsl` setting based on Multiplayer Status Data (via MpCore / `MpStatusRepository`)
- Bumps plugin version to 2.3.0